### PR TITLE
Fix using an empty string as cookie value

### DIFF
--- a/jcookie.js
+++ b/jcookie.js
@@ -67,7 +67,7 @@ jQuery.jCookie = function(sCookieName_, oValue_, oExpires_, oOptions_) {
 	var sExpires_ = "";
 
 	// write ('n delete ) cookie even in case the value === null
-	if (oValue_ || (oValue_ === null && arguments.length == 2)) {
+	if (oValue_ !== undefined) {
 
 		// set preceding expire date in case: expires === null, or the arguments have been (STRING,NULL)
 		oExpires_ = (oExpires_ === null || (oValue_ === null && arguments.length == 2)) ? -1 : oExpires_;


### PR DESCRIPTION
The current implementation does not allow to set an empty string, `0` or `false` as cookie value. The if condition will never be executed due to the `if (oValue_)` check. I have therefore replaced it with `if (oValue_ !== undefined)`.
